### PR TITLE
Switch hacklog.in to tag feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -1148,7 +1148,7 @@ title = Planet openSUSE
 
 [ishsookun]
   title    = Ish Sookun
-  feed     = https://hacklog.in/rss/
+  feed     = https://hacklog.in/tag/opensuse/rss/
   link     = https://hacklog.in
   location = en
   avatar   = ish-sookun.jpg


### PR DESCRIPTION
As hacklog.in has a dedicated tag feed for openSUSE let's use it.