### PR TITLE
Workaround "error: SSL_connect" causing stopping processing

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -1212,13 +1212,6 @@ title = Planet openSUSE
   location = en
   author   = irc:tgeek member
 
-[aaronluna]
-  title    = Aaron Luna
-  feed     = https://www.opensusemexico.com/feeds/posts/default
-  link     = https://www.opensusemexico.com
-  location = es
-  author   = irc:aluna connect:aaronluna75 member
-
 [martindeboer]
   title    = Martin de Boer
   feed     = https://www.fossadventures.com/feed/
@@ -1400,3 +1393,12 @@ title = Planet openSUSE
   avatar   = medwinz.png
   author   = irc:slowhand member
   email    = medwin@opensuse.org
+
+# This causes "error: SSL_connect SYSCALL returned=5 errno=0 peeraddr=34.98.99.30:443 state=SSLv3/TLS write client hello"
+# and stops processing further blogs. As a workaround, moved to the end.
+[aaronluna]
+  title    = Aaron Luna
+  feed     = https://www.opensusemexico.com/feeds/posts/default
+  link     = https://www.opensusemexico.com
+  location = es
+  author   = irc:aluna connect:aaronluna75 member


### PR DESCRIPTION
Unlike other errors this is not being ignored but seems to stop further processing.

With this change rake runs to the end and also allows the blog in question to come back once it works.