### PR TITLE
Update federico's blog URLs

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -42,9 +42,9 @@ title = Planet openSUSE
 
 [federicomenaquintero]
   title    = Federico Mena-Quintero
-  feed     = https://people.gnome.org/~federico/blog/feeds/all.atom.xml
-  link     = https://people.gnome.org/~federico/blog/
-  avatar   = https://planet.gnome.org/heads/federico2.png
+  feed     = https://viruta.org/feeds/atom.xml
+  link     = https://viruta.org/
+  avatar   = https://planet.gnome.org/heads/federico.png
   author   = irc:federico1 member
 
 [marcusmeissner]


### PR DESCRIPTION
people.gnome.org got decommissioned recently, and I moved my blog to its own hosting.