### PR TITLE
Removed vavai.com from the list

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -742,13 +742,6 @@ title = Planet openSUSE
   avatar   = thomas_thym.png
   author   = irc:ungethym
 
-[masimvavaisugianto]
-  title    = Masim Vavai Sugianto
-  feed     = https://www.vavai.com/category/linux/feed/
-  link     = https://www.vavai.com/category/linux/
-  location = id
-  author   = irc:vavai member
-
 [andressilva]
   title    = Andres Silva
   feed     = https://anditosan.blogspot.com/feeds/posts/default?alt=rss


### PR DESCRIPTION
Removed vavai.com as it doesn't publish any FOSS , Linux or openSUSE related content and only one blog post was posted on /linux and was a hiring post.