### PR TITLE
Add the Agama installer blog

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -14,6 +14,12 @@ title = Planet openSUSE
   location = en
   avatar   = yast.png
 
+[agama]
+  title    = Agama Installer
+  feed     = https://agama-project.github.io/blog/atom.xml
+  link     = https://agama-project.github.io/blog
+  location = en
+
 [openbuildservice]
   title    = Open Build Service
   feed     = https://openbuildservice.org/feed/


### PR DESCRIPTION
To avoid confusion we (the YaST team) won't publish the new Agama installer blog posts in the YaST blog anymore. We created a new place for that at https://agama-project.github.io/blog.

Please include this Agama blog at planet.o.o, thank you!