### PR TITLE
Upgrade Ruby version in Jekyll CI workflow

### DIFF
--- a/.github/workflows/feeds.yml
+++ b/.github/workflows/feeds.yml
@@ -6,10 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
-
-
 jobs:
-  build:
+  feed-check:
 
     runs-on: ubuntu-latest
 
@@ -17,7 +15,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Install dependencies
-      uses: docker://ruby:3.2.9
+      uses: docker://ruby:3.4.3
       env:
         BUNDLE_PATH: .bundle
       with:
@@ -25,7 +23,7 @@ jobs:
         args: install -j=4
 
     - name: Run the tests
-      uses: docker://ruby:3.2.9
+      uses: docker://ruby:3.4.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-
-
 jobs:
   build:
 
@@ -17,7 +15,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Install dependencies
-      uses: docker://ruby:3.2.9
+      uses: docker://ruby:3.4.3
       env:
         BUNDLE_PATH: .bundle
       with:
@@ -25,7 +23,7 @@ jobs:
         args: install -j=4
 
     - name: Fetch the content
-      uses: docker://ruby:3.2.9
+      uses: docker://ruby:3.4.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8
@@ -36,7 +34,7 @@ jobs:
         args: exec rake
 
     - name: Build the site
-      uses: docker://ruby:3.2.9
+      uses: docker://ruby:3.4.3
       env:
         BUNDLE_PATH: .bundle
         LANG: en_US.UTF-8


### PR DESCRIPTION
Updated Ruby version from 3.2.9 to 3.4.3 as requested in #109 